### PR TITLE
Restructure calculator into package skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# 科学计算器
+
+该项目提供了一个科学计算器库以及命令行界面。
+
+## 安装
+
+```bash
+pip install -e .
+```
+
+## 使用
+
+运行交互式计算器：
+
+```bash
+scicalc
+```
+
+或在 Python 中使用：
+
+```python
+from scicalc import evaluate
+print(evaluate("2 + 2"))
+```
+
+wocaonima

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "scicalc"
+version = "0.1.0"
+description = "Interactive scientific calculator"
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [{name = "Unknown"}]
+dependencies = []
+
+[project.scripts]
+scicalc = "scicalc.__main__:main"

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,0 @@
-wocaonima 

--- a/src/scicalc/__init__.py
+++ b/src/scicalc/__init__.py
@@ -1,0 +1,5 @@
+"""Scientific calculator package."""
+
+from .core import evaluate
+
+__all__ = ["evaluate"]

--- a/src/scicalc/__main__.py
+++ b/src/scicalc/__main__.py
@@ -1,19 +1,10 @@
-#!/usr/bin/env python3
-"""Interactive scientific calculator."""
-import math
+"""Command-line interface for the scientific calculator."""
 
-# Build a dictionary of allowed names from the math module
-ALLOWED_NAMES = {k: getattr(math, k) for k in dir(math) if not k.startswith("_")}
-ALLOWED_NAMES.update({"abs": abs, "round": round})
-
-
-def evaluate(expression: str) -> float:
-    """Safely evaluate a math expression using only allowed names."""
-    expression = expression.replace("^", "**")  # allow ^ for exponent
-    return eval(expression, {"__builtins__": {}}, ALLOWED_NAMES)
+from .core import evaluate
 
 
 def main() -> None:
+    """Run the interactive calculator REPL."""
     print("Scientific Calculator. Type 'exit' or 'quit' to exit.")
     while True:
         try:

--- a/src/scicalc/core.py
+++ b/src/scicalc/core.py
@@ -1,0 +1,15 @@
+"""Core evaluation logic for the scientific calculator."""
+
+from __future__ import annotations
+
+import math
+
+# Build a dictionary of allowed names from the math module
+ALLOWED_NAMES = {k: getattr(math, k) for k in dir(math) if not k.startswith("_")}
+ALLOWED_NAMES.update({"abs": abs, "round": round})
+
+
+def evaluate(expression: str) -> float:
+    """Safely evaluate a math expression using only allowed names."""
+    expression = expression.replace("^", "**")  # allow ^ for exponent
+    return eval(expression, {"__builtins__": {}}, ALLOWED_NAMES)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,9 @@
+from scicalc import evaluate
+
+
+def test_addition():
+    assert evaluate("2 + 2") == 4
+
+
+def test_trigonometry():
+    assert round(evaluate("sin(pi / 2)"), 8) == 1.0


### PR DESCRIPTION
## Summary
- reorganize calculator into `scicalc` package with CLI and evaluation logic
- add packaging metadata, basic tests, and Chinese README ending with `wocaonima`
- provide project README and ignore generated files

## Testing
- `PYTHONPATH=src python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b00fda1538832bb655a66f55e18a25