### PR TITLE
feat: add web calculator and docker compose tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,21 +16,21 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - name: Build images
-        run: docker compose -f compose.test.yml build
+        run: docker compose -f ./compose.test.yml build
 
       - name: Start dependencies
-        run: docker compose -f compose.test.yml up -d db redis
+        run: docker compose -f ./compose.test.yml up -d db redis
 
       - name: Run tests
-        run: docker compose -f compose.test.yml run --rm sut pytest -q
+        run: docker compose -f ./compose.test.yml run --rm sut pytest -q
 
       - name: Teardown
         if: always()
-        run: docker compose -f compose.test.yml down -v
+        run: docker compose -f ./compose.test.yml down -v
 
       - name: Collect logs
         if: always()
-        run: docker compose -f compose.test.yml logs --no-color > compose.log || true
+        run: docker compose -f ./compose.test.yml logs --no-color > compose.log || true
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,7 @@ RUN pip install --no-cache-dir -r requirements.txt && pip install --no-cache-dir
 COPY . .
 
 # 默认命令（CI里不会用到，compose 的 sut 会覆盖为 pytest）
-CMD ["python", "-c", "print('image ready')"]
+EXPOSE 8000
+
+# 默认运行内置的简易 HTTP 服务器，提供前端页面和计算接口
+CMD ["python", "-m", "scicalc.web"]

--- a/README.md
+++ b/README.md
@@ -1,44 +1,49 @@
-
 # 科学计算器
 
-该项目提供了一个科学计算器库以及命令行界面。
+一个包含科学计算核心库、命令行工具以及基于浏览器前端的示例项目。项目支持常见的科学函数，既可本地运行，也可通过 Docker 部署。
 
-## 安装
+## 功能概览
+- `scicalc.evaluate` 函数可安全地计算字符串表达式，支持 `sin`、`cos`、`tan`、`pi`、幂运算等常用功能。
+- 提供交互式命令行工具 `scicalc`。
+- 内置 HTTP 服务器暴露 `/api/evaluate` 接口，并提供可点击的 Web 计算器界面。
 
-# Scientific Calculator
-
-This project provides a scientific calculator library and command line interface.
-
-## Installation
-
-
+## 安装与使用库
 ```bash
 pip install -e .
 ```
 
+在 Python 中调用：
+```python
+from scicalc import evaluate
+print(evaluate("sin(pi/2)"))
+```
 
-## 使用
-
-运行交互式计算器：
-
-## Usage
-
-Run the interactive calculator:
-
-
+## 命令行
 ```bash
 scicalc
 ```
 
-或在 Python 中使用：
+## Web 前端
+启动轻量级 Web 服务器：
+```bash
+python -m scicalc.web
+```
+打开 [http://localhost:8000](http://localhost:8000) 后，可通过按钮输入表达式并按 `=` 计算。
 
-Or use from Python:
+## Docker 运行
+```bash
+docker build -t scicalc .
+docker run -p 8000:8000 scicalc
+```
+容器启动后同样访问 `http://localhost:8000`。
 
-
-```python
-from scicalc import evaluate
-print(evaluate("2 + 2"))
-
-
-wocaonima
-
+## 测试
+在本地运行单元测试：
+```bash
+PYTHONPATH=src pytest -q
+```
+也可以使用 Docker Compose 在隔离环境下运行：
+```bash
+docker compose -f compose.test.yml build
+docker compose -f compose.test.yml run --rm sut
+```

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -20,7 +20,7 @@ services:
   # 你的应用镜像（测试与运行共用同一镜像）
   app:
     build: .
-    image: yourapp:test
+    image: scicalc:test
     environment:
       DATABASE_URL: postgresql://postgres:postgres@db:5432/postgres
       REDIS_URL: redis://redis:6379/0
@@ -30,7 +30,7 @@ services:
 
   # SUT（system under test）：跑 pytest
   sut:
-    image: yourapp:test
+    image: scicalc:test
     working_dir: /app
     command: pytest -q
     environment:

--- a/src/scicalc/static/index.html
+++ b/src/scicalc/static/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Scientific Calculator</title>
+    <style>
+        body { font-family: Arial, sans-serif; }
+        #calculator { width: 260px; margin: 20px auto; }
+        #display { width: 100%; height: 40px; text-align: right; font-size: 24px; margin-bottom: 5px; }
+        .row { display: flex; }
+        .btn { flex: 1; height: 40px; margin: 2px; font-size: 18px; }
+    </style>
+</head>
+<body>
+    <div id="calculator">
+        <input id="display" type="text" readonly />
+        <div class="row">
+            <button class="btn" data-value="7">7</button>
+            <button class="btn" data-value="8">8</button>
+            <button class="btn" data-value="9">9</button>
+            <button class="btn" data-value="/">/</button>
+        </div>
+        <div class="row">
+            <button class="btn" data-value="4">4</button>
+            <button class="btn" data-value="5">5</button>
+            <button class="btn" data-value="6">6</button>
+            <button class="btn" data-value="*">*</button>
+        </div>
+        <div class="row">
+            <button class="btn" data-value="1">1</button>
+            <button class="btn" data-value="2">2</button>
+            <button class="btn" data-value="3">3</button>
+            <button class="btn" data-value="-">-</button>
+        </div>
+        <div class="row">
+            <button class="btn" data-value="0">0</button>
+            <button class="btn" data-value=".">.</button>
+            <button class="btn" id="clear">C</button>
+            <button class="btn" data-value="+">+</button>
+        </div>
+        <div class="row">
+            <button class="btn" data-value="(">(</button>
+            <button class="btn" data-value=")">)</button>
+            <button class="btn" data-value="sin(">sin</button>
+            <button class="btn" data-value="cos(">cos</button>
+        </div>
+        <div class="row">
+            <button class="btn" data-value="tan(">tan</button>
+            <button class="btn" data-value="pi">π</button>
+            <button class="btn" data-value="^">^</button>
+            <button class="btn" id="equals">=</button>
+        </div>
+    </div>
+    <script>
+        const display = document.getElementById('display');
+        document.querySelectorAll('.btn[data-value]').forEach(btn => {
+            btn.addEventListener('click', () => {
+                display.value += btn.dataset.value;
+            });
+        });
+        document.getElementById('clear').addEventListener('click', () => {
+            display.value = '';
+        });
+        document.getElementById('equals').addEventListener('click', async () => {
+            const expr = display.value;
+            const resp = await fetch('/api/evaluate', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ expression: expr })
+            });
+            const data = await resp.json();
+            display.value = data.result !== undefined ? data.result : 'Error';
+        });
+    </script>
+</body>
+</html>

--- a/src/scicalc/web.py
+++ b/src/scicalc/web.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from pathlib import Path
+from .core import evaluate
+
+STATIC_DIR = Path(__file__).resolve().parent / "static"
+
+
+class Handler(SimpleHTTPRequestHandler):
+    """HTTP handler serving static files and evaluation API."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=str(STATIC_DIR), **kwargs)
+
+    def do_GET(self) -> None:  # pragma: no cover - simple delegation
+        if self.path in {"", "/"}:
+            self.path = "/index.html"
+        super().do_GET()
+
+    def do_POST(self) -> None:
+        if self.path != "/api/evaluate":
+            self.send_error(404, "Not Found")
+            return
+        length = int(self.headers.get("Content-Length", 0))
+        data = json.loads(self.rfile.read(length))
+        expression = data.get("expression", "")
+        try:
+            result = evaluate(expression)
+            response, status = {"result": result}, 200
+        except Exception as exc:  # noqa: BLE001 - broad for user errors
+            response, status = {"error": str(exc)}, 400
+        body = json.dumps(response).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def create_server(host: str = "0.0.0.0", port: int = 8000) -> HTTPServer:
+    """Create an HTTP server instance."""
+    return HTTPServer((host, port), Handler)
+
+
+def run(host: str = "0.0.0.0", port: int = 8000) -> None:
+    """Run the HTTP server."""
+    httpd = create_server(host, port)
+    print(f"Serving on http://{host}:{port}")
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:  # pragma: no cover - manual interruption
+        pass
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,24 @@
+import json
+import threading
+from urllib.request import Request, urlopen
+
+from scicalc.web import create_server
+
+
+def test_api_evaluate():
+    server = create_server(host="127.0.0.1", port=8765)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        req = Request(
+            "http://127.0.0.1:8765/api/evaluate",
+            data=json.dumps({"expression": "2+2"}).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        with urlopen(req) as resp:
+            assert resp.status == 200
+            data = json.load(resp)
+        assert data["result"] == 4
+    finally:
+        server.shutdown()
+        thread.join()


### PR DESCRIPTION
## Summary
- serve scientific-calculator UI and evaluation API
- provide root-level docker compose config and update CI workflow to use it

## Testing
- `PYTHONPATH=src pytest -q`
- `docker compose -f compose.test.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1174cf210832bba3319ea0b10e44a